### PR TITLE
fix(issue-17): remove transparent blurred nav on scroll

### DIFF
--- a/_components/Navbar.tsx
+++ b/_components/Navbar.tsx
@@ -11,7 +11,7 @@ import { CustomThemeSelector } from './ThemeToggle';
 export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const pathname = usePathname();
-  const [isScrolled, setIsScrolled] = useState(false);
+  // const [isScrolled, setIsScrolled] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -25,11 +25,11 @@ export default function Navbar() {
     { href: '/contact', label: 'Contact' },
   ];
 
-  useEffect(() => {
-    const handleScroll = () => setIsScrolled(window.scrollY > 50);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  // useEffect(() => {
+  //   const handleScroll = () => setIsScrolled(window.scrollY > 50);
+  //   window.addEventListener('scroll', handleScroll);
+  //   return () => window.removeEventListener('scroll', handleScroll);
+  // }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -50,11 +50,7 @@ export default function Navbar() {
   }, [mobileMenuOpen]);
 
   return (
-    <header
-      className={`nav-header ${
-        isScrolled ? 'nav-header-scrolled' : 'nav-header-transparent'
-      }`}
-    >
+    <header className="nav-header">
       <nav
         aria-label="navigation bar"
         className="container mx-auto px-6 py-4"

--- a/styles/components/navigation.css
+++ b/styles/components/navigation.css
@@ -1,17 +1,9 @@
 @layer components {
   .nav-header {
     @apply row-start-1 sticky top-0 w-full z-50 transition-all duration-300;
-  }
-
-  .nav-header-scrolled {
-    backdrop-filter: blur(16px);
-    box-shadow: var(--shadow-sm);
-    color: var(--secondary-foreground);
-  }
-
-  .nav-header-transparent {
-    background-color: transparent;
+    background-color: var(--background);
     color: var(--foreground);
+    box-shadow: var(--shadow-sm);
   }
 
   .nav-link {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -79,7 +79,7 @@
     --primary-foreground: #fefefe;
     --secondary: #589c77;
     --secondary-foreground: #fefefe;
-    --accent: #f9f9f9;
+    --accent: #d1d1d1;
     --accent-foreground: #333333;
     --destructive: #ef4444;
     --destructive-foreground: #fefefe;
@@ -113,7 +113,7 @@
     --primary-foreground: #1a1a1a;
     --secondary: #80ab68;
     --secondary-foreground: #1a1a1a;
-    --accent: #333333;
+    --accent: #555555;
     --accent-foreground: #f9f9f9;
     --destructive: #ef4444;
     --destructive-foreground: #f9f9f9;
@@ -142,7 +142,7 @@
     --primary-foreground: #fefefe;
     --secondary: #589c77;
     --secondary-foreground: #fefefe;
-    --accent: #f9f9f9;
+    --accent: #d1d1d1;
     --accent-foreground: #333333;
     --destructive: #ef4444;
     --destructive-foreground: #fefefe;
@@ -166,7 +166,7 @@
       --primary-foreground: #1a1a1a;
       --secondary: #80ab68;
       --secondary-foreground: #1a1a1a;
-      --accent: #333333;
+      --accent: #555555;
       --accent-foreground: #f9f9f9;
       --destructive: #ef4444;
       --destructive-foreground: #f9f9f9;


### PR DESCRIPTION
fixes #17 

- removed feature where navbar background went transparent on scrolling to improve the contrast between blurred background and navbar items when a user scrolls down the page.
- updated styles accordingly.